### PR TITLE
Backport some build improvements from upstream

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -51,7 +51,7 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 # hadolint ignore=DL3003
 RUN git clone -b v1.13 https://github.com/zeux/pugixml && \
     cd pugixml && \
-    cmake -DBUILD_SHARED_LIBS=ON && \
+    cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON && \
     make all && \
     cp -P libpugixml.so* /usr/lib64/
 
@@ -196,6 +196,7 @@ RUN if [ "$ov_use_binary" = "1" ] && [ "$DLDT_PACKAGE_URL" != "" ]; then true ; 
 # install sample apps including benchmark_app
 RUN yum install -y http://mirror.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/gflags-devel-2.2.2-1.el8.x86_64.rpm \
     http://mirror.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/gflags-2.2.2-1.el8.x86_64.rpm \
+    https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/tbb-devel-2018.2-9.el8.x86_64.rpm \
     https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/j/json-devel-3.6.1-2.el8.x86_64.rpm && \
     rm -rf /var/cache/yum
 RUN if [ -f /opt/intel/openvino/samples/cpp/build_samples.sh ];  then /opt/intel/openvino/samples/cpp/build_samples.sh ; fi
@@ -203,6 +204,7 @@ RUN if [ -f /opt/intel/openvino/samples/cpp/build_samples.sh ];  then /opt/intel
 
 # SENTENCEPIECE_EXTENSION
 ENV OpenVINO_DIR=/opt/intel/openvino/runtime/cmake
+ENV TBB_DIR=/openvino/cmake/developer_package/tbb/lnx/
 WORKDIR /openvino_contrib/modules/custom_operations/user_ie_extensions
 RUN if [ "$sentencepiece" == "1" ] ; then true ; else exit 0 ; fi ; cmake .. -DCMAKE_BUILD_TYPE=Release -DCUSTOM_OPERATIONS="tokenizer" && cmake --build . --parallel $JOBS
 

--- a/third_party/azure/azure_sdk.patch
+++ b/third_party/azure/azure_sdk.patch
@@ -7,7 +7,7 @@ index ac9e65d..fd2aca4 100644
    set(WARNINGS "${WARNINGS} ${LINUX_SUPPRESSIONS}")
  
 -  set(LD_FLAGS "${LD_FLAGS} -Wl,-z,defs")
-+  set(LD_FLAGS "${LD_FLAGS} -Wl,-z,defs,--exclude-libs,ALL")
++  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs,--exclude-libs,ALL")
  
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing")
  


### PR DESCRIPTION
## Description
This patch adds the following improvements:
1) Make pugixml a "release" build
2) Add tbb for the sentence_piece extention
3) Correct adding linker flags to azure build

## How Has This Been Tested?
This has been tested with podman build --tag my:model_server --build-arg RUN_TESTS=0  --build-arg BUILDAH_FORMAT=docker --build-arg ov_use_binary=0 --build-arg BASE_OS=redhat --build-arg RH_ENTITLEMENT=0 --build-arg ov_source_branch='releases/2024/0' --build-arg ov_contrib_branch='releases/2024/0' -f Dockerfile.redhat

There was another patch that is upstream that makes the build verbose. The logs were reviewed to ensure the right flags were used and the missing TBB messages go away.

## Merge criteria:
- [ x ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ x ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ x ] The developer has manually tested the changes and verified that the changes work
