### PR TITLE
Fix missing XNNPACK

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -156,7 +156,7 @@ ARG ov_use_binary=0
 ARG DLDT_PACKAGE_URL
 ARG TEMP_DIR=/tmp/openvino_installer
 ARG CMAKE_BUILD_TYPE=Release
-ARG debug_bazel_flags=--strip=never
+ARG debug_bazel_flags="--strip=always --define MEDIAPIPE_DISABLE=0 --define PYTHON_DISABLE=0 --//:distro=redhat"
 
 # hadolint ignore=DL3003
 RUN if [[ "$sentencepiece" == "1" || "$NVIDIA" == "1" ]] ; then true ; else exit 0 ; fi ; git clone https://github.com/$ov_contrib_org/openvino_contrib.git /openvino_contrib && cd /openvino_contrib && git checkout $ov_contrib_branch && git submodule update --init --recursive
@@ -317,7 +317,7 @@ RUN bash -c "sed -i -e 's|REPLACE_PROJECT_NAME|${PROJECT_NAME}|g' /ovms/src/vers
     bash -c "sed -i -e 's|REPLACE_BAZEL_BUILD_FLAGS|${debug_bazel_flags}${minitrace_flags}|g' /ovms/src/version.hpp"
 
 # C api shared library
-ARG CAPI_FLAGS=--strip=always --define MEDIAPIPE_DISABLE=1 --cxxopt=-DMEDIAPIPE_DISABLE=1 --define PYTHON_DISABLE=1 --cxxopt=-DPYTHON_DISABLE=1
+ARG CAPI_FLAGS="--strip=always --define MEDIAPIPE_DISABLE=1 --define PYTHON_DISABLE=1 --//:distro=redhat"
 RUN bazel build --jobs $JOBS ${CAPI_FLAGS} //src:ovms_shared
 
 # C api app with bazel


### PR DESCRIPTION


## Description
The Dockerfile has some bad flags in it. This leads to ultimately not finding XNNPACK which terminates the build. This was reported upstream as Issue #2391. It was fixed by PR #2414. This patch picks the important part of the PR. Applying this allows the build to complete successfully.

## How Has This Been Tested?
This was tested using: podman build --tag my:model_server --build-arg RUN_TESTS=0  --build-arg BUILDAH_FORMAT=docker --build-arg ov_use_binary=0 --build-arg BASE_OS=redhat --build-arg RH_ENTITLEMENT=0 --build-arg ov_source_branch='releases/2024/0' --build-arg ov_contrib_branch='releases/2024/0' -f Dockerfile.redhat

## Merge criteria:
- [ x ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ x ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ x ] The developer has manually tested the changes and verified that the changes work
