### PR TITLE
Use dnf if available

### DIFF
--- a/demos/python_demos/Dockerfile.redhat
+++ b/demos/python_demos/Dockerfile.redhat
@@ -18,7 +18,8 @@ FROM ${IMAGE_NAME}
 USER root
 ENV LD_LIBRARY_PATH=/ovms/lib
 ENV PYTHONPATH=/ovms/lib/python
-RUN microdnf install python39-pip git
+RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; else export DNF_TOOL=microdnf ; fi ; \
+	$DNF_TOOL install python39-pip git
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 ENTRYPOINT [ "/ovms/bin/ovms" ]


### PR DESCRIPTION
The current demo is coded to use microdnf. This fixes it to use either dnf or microdnf whichever is on the image.
