### PR TITLE
Cleanup and add Python Demos requirements

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -167,8 +167,8 @@ RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; git clone ht
 RUN if [ "$ov_use_binary" == "0" ]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; pip3 install --no-cache-dir -r /openvino/src/bindings/python/wheel/requirements-dev.txt
 WORKDIR /openvino/build
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; dnf install -y http://vault.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/opencl-headers-2.2-1.20180306gite986688.el8.noarch.rpm && dnf clean all
-RUN if [ "$ov_use_binary" == "0" ] && [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DENABLE_PYTHON=ON -DENABLE_SAMPLES=0 -DNGRAPH_USE_CXX_ABI=1 -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=parentheses "  ..
-RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; cmake -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" -DCMAKE_VERBOSE_MAKEFILE=ON -DENABLE_SAMPLES=0 -DNGRAPH_USE_CXX_ABI=1 -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=parentheses " ..
+RUN if [ "$ov_use_binary" == "0" ]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DENABLE_PYTHON=ON -DENABLE_SAMPLES=0 -DNGRAPH_USE_CXX_ABI=1 -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=parentheses " ..
+RUN if [ "$ov_use_binary" == "0" ] && [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DENABLE_SAMPLES=0 -DNGRAPH_USE_CXX_ABI=1 -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=parentheses " ..
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; make --jobs=$JOBS
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; make install
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; \
@@ -215,6 +215,12 @@ ENV OPENVINO_CONTRIB=/openvino_contrib
 
 # hadolint ignore=DL3003
 RUN if [ "$NVIDIA" == "1" ] ; then true ; else exit 0 ; fi ; \
+    echo "=================== Dump CUDA Env ===============" && \
+    env | grep -i CUDA && \
+    echo "PATH=$PATH" && \
+    ls -l /usr/local/cuda/bin ||: && \
+    rpm -qi redhat-release && \
+    echo "=================== End CUDA Env ================" && \
     mkdir "${OPENVINO_BUILD_PATH}" && \
     cd "${OPENVINO_BUILD_PATH}" && \
     cmake "${OPENVINO_HOME}" \
@@ -396,7 +402,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3003,DL3041,SC2164
 RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; else export DNF_TOOL=microdnf ; fi ; \
         $DNF_TOOL upgrade --setopt=install_weak_deps=0 -y ; \
-        $DNF_TOOL install -y pkg-config && rpm -ivh https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/tbb-2018.2-9.el8.x86_64.rpm && \
+        $DNF_TOOL install --nodocs -y pkg-config && rpm -ivh https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/tbb-2018.2-9.el8.x86_64.rpm && \
         if [ "$GPU" == "1" ] ; then \
                 case $INSTALL_DRIVER_VERSION in \
                 "21.38.21026") \
@@ -469,30 +475,35 @@ RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; else export DNF_TOOL=mic
         fi ; \
         # For image with Python enabled install Python library
         if ! [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then \
-            $DNF_TOOL install -y python39-libs --setopt=install_weak_deps=0; \
+            $DNF_TOOL install -y python39-libs --setopt=install_weak_deps=0 --nodocs; \
             mkdir -p /ovms/lib/openvino-2024.2.dist-info && \
             echo $'Metadata-Version: 1.0\nName: openvino\nVersion: 2024.2' > /ovms/lib/openvino-2024.2.dist-info/METADATA ; \
         fi ; \
-        $DNF_TOOL install -y shadow-utils; \
+        $DNF_TOOL clean all ; \
         cp -v /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt ; \
         groupadd --gid 5000 ovms && groupadd --gid 44 video1 && \
         useradd --home-dir /home/ovms --create-home --uid 5000 --gid 5000 --groups 39,44 --shell /bin/bash --skel /dev/null ovms
 
 # for NVIDIA
 RUN if [ "$NVIDIA" == "1" ]; then true ; else exit 0 ; fi ; echo "installing cuda yum package"; \
-    dnf install -y  \
+    dnf install -y --nodocs \
         libcudnn8-8.6.0.163-1.cuda11.8 \
         libcutensor1-1.6.1.5-1 && \
         dnf clean all
 
 ENV LD_LIBRARY_PATH=/ovms/lib
-
 COPY --from=pkg /ovms_release /ovms
 COPY --from=build /usr/local/lib/python3.*/site-packages/jinja2 /ovms/python_deps/jinja2
 COPY --from=build /usr/local/lib/python3.*/site-packages/jinja2-3.1.4.dist-info /ovms/python_deps/jinja2-3.1.4.dist-info
 COPY --from=build /usr/local/lib64/python3.*/site-packages/MarkupSafe-2.1.5.dist-info /ovms/python_deps/MarkupSafe-2.1.5.dist-info
 COPY --from=build /usr/local/lib64/python3.*/site-packages/markupsafe /ovms/python_deps/markupsafe
-
 COPY --from=pkg /licenses /licenses
+
+# Setup Python Demos Environment
+RUN dnf install --nodocs -y python39-pip git && dnf clean all
+COPY demos/python_demos/requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt && rm -f requirements.txt && \
+    python3 -c "import nltk; nltk.download('averaged_perceptron_tagger'); nltk.download('punkt')"
+
 USER ovms
 ENTRYPOINT ["/ovms/bin/ovms"]

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -292,7 +292,7 @@ RUN make
 RUN if ! [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; \
     mkdir -p /opt/intel/openvino/python/openvino-2024.2.dist-info && \
     echo $'Metadata-Version: 1.0\nName: openvino\nVersion: 2024.2' > /opt/intel/openvino/python/openvino-2024.2.dist-info/METADATA
-ENV PYTHONPATH=/opt/intel/openvino/python:/ovms/bazel-bin/src/python/binding
+ENV PYTHONPATH=/opt/intel/openvino/python:/ovms/bazel-bin/src/python/binding:/usr/local/lib/python3.9/site-packages
 
 WORKDIR /ovms
 
@@ -501,8 +501,7 @@ COPY --from=pkg /licenses /licenses
 
 # Setup Python Demos Environment
 RUN dnf install --nodocs -y python39-pip git && dnf clean all
-COPY demos/python_demos/requirements.txt .
-RUN pip3 install --no-cache-dir -r requirements.txt && rm -f requirements.txt && \
+RUN pip3 install --no-cache-dir -r demos/python_demos/requirements.txt && \
     python3 -c "import nltk; nltk.download('averaged_perceptron_tagger'); nltk.download('punkt')"
 
 USER ovms

--- a/demos/python_demos/requirements.txt
+++ b/demos/python_demos/requirements.txt
@@ -10,6 +10,7 @@ tritonclient[grpc]==2.37.0.9383150  # Required to use batch string serialization
 transformers==4.40
 diffusers==0.26.3
 datasets==2.18.0
+numpy<2.0
 
 # Required for RAG Chatbot Demo:
 langchain==0.1.12


### PR DESCRIPTION
This patch does 5 things.
    1) It replaces very complicated decision login with code from Ubuntu's
    2) It dumps the CUDA environment for debugging purposes
    3) It adds --nodocs to yum and dnf command to drop documentation
    4) It installs the requirements for the Python Demos
    5) And it constrains the numpy version due to a binary incompatibility

Jira Issue [RHOAIENG-10730](https://issues.redhat.com//browse/RHOAIENG-10730)