### PR TITLE
 Add script to wait for the model to appear when using KServe Modelcar

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -494,6 +494,7 @@ COPY --from=build /usr/local/lib/python3.*/site-packages/jinja2-3.1.4.dist-info 
 COPY --from=build /usr/local/lib64/python3.*/site-packages/MarkupSafe-2.1.5.dist-info /ovms/python_deps/MarkupSafe-2.1.5.dist-info
 COPY --from=build /usr/local/lib64/python3.*/site-packages/markupsafe /ovms/python_deps/markupsafe
 COPY --from=pkg /licenses /licenses
+COPY --chown=ovms:0 --chmod=554 extras/wait-modelcar.sh /ovms/bin/
 
 # Setup Python Demos Environment
 RUN dnf install --nodocs -y python39-pip git && dnf clean all
@@ -502,4 +503,4 @@ RUN pip3 install --no-cache-dir -r requirements.txt && \
     python3 -c "import nltk; nltk.download('averaged_perceptron_tagger'); nltk.download('punkt')" && rm -f requirements.txt
 
 USER ovms
-ENTRYPOINT ["/ovms/bin/ovms"]
+ENTRYPOINT ["/ovms/bin/wait-modelcar.sh"]

--- a/extras/wait-modelcar.sh
+++ b/extras/wait-modelcar.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "${MODEL_INIT_MODE}" = "async" ] ; then
+  echo "Waiting for model files (modelcar) to be present..."
+  until test -e /mnt/models; do
+    sleep 1
+  done
+
+  echo "Model files are now available."
+fi
+
+echo "Starting model server..."
+/ovms/bin/ovms $@
+


### PR DESCRIPTION
When using OCI containers for model storage in KServe (modelcar), there is the possibility that the model server starts before the model has been fully downloaded. When this happens, the model server would terminate with error because the model path is empty.

This adds a small script to wait for the cluster to fully download the model container before invoking the model server. The waiting is triggered when the MODEL_INIT_MODE environment variable is set to "async".
