### PR TITLE
Fix dnf parallelism

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -29,7 +29,7 @@ SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 ARG JOBS=8
 ARG VERBOSE_LOGS=OFF
 
-RUN echo "max_parallel_downloads=8\nretries=50" >> /etc/dnf/dnf.conf && \
+RUN echo -e "max_parallel_downloads=8\nretries=50" >> /etc/dnf/dnf.conf && \
    dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf update -d6 -y && dnf install -d6 -y \
             libuuid-devel \
             bc \
@@ -399,7 +399,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3003,DL3041,SC2164
 RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; else export DNF_TOOL=microdnf ; fi ; \
         chmod 0644 /etc/yum.repos.d/* ; \
-        echo "max_parallel_downloads=8\nretries=50" >> /etc/dnf/dnf.conf ; \
+        echo -e "max_parallel_downloads=8\nretries=50" >> /etc/dnf/dnf.conf ; \
         $DNF_TOOL upgrade --setopt=install_weak_deps=0 --setopt=max_parallel_downloads=8 -y ; \
         $DNF_TOOL install --nodocs -y pkg-config https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/tbb-2018.2-9.el8.x86_64.rpm && \
         if [ "$GPU" == "1" ] ; then \


### PR DESCRIPTION
### 🛠 Summary
A '-e' parameter was missing to the echo statement updating the dnf.conf file. It won't break the build, but it also doesn't let the retries work either. This adds the missing '-e'.
