### PR TITLE
Update python packages to clear vulnerabilities

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -503,7 +503,8 @@ COPY --from=pkg /licenses /licenses
 RUN dnf install --nodocs -y python39-pip git && dnf clean all
 COPY demos/python_demos/requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt && \
-    python3 -c "import nltk; nltk.download('averaged_perceptron_tagger'); nltk.download('punkt')" && rm -f requirements.txt
+    python3 -c "import nltk; nltk.download('averaged_perceptron_tagger'); nltk.download('punkt')" && rm -f requirements.txt && \
+    pip3 install --no-cache-dir langchain-community==0.3.0 langchain==0.3.1
 
 USER ovms
 ENTRYPOINT ["/ovms/bin/ovms"]


### PR DESCRIPTION
Update langchain-community to 0.3.0 and langchain to 0.3.1 to solve a vulnerability report.