### PR TITLE
OVMS update for the 2.19 release

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,7 @@
 # Optimizations used for TF Serving release builds.
 build:release --copt=-mavx
 build:release --copt=-msse4.2
+build:linux --copt="-march=haswell"
 
 # Options used to build with CUDA.
 build:cuda --crosstool_top=@local_config_cuda//crosstool:toolchain

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -26,6 +26,9 @@ SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 ARG JOBS=8
 ARG VERBOSE_LOGS=OFF
+ARG LTO_ENABLE=OFF
+ARG LTO_CXX_FLAGS=""
+ARG LTO_LD_FLAGS="-Wl,-z,relro"
 
 # hadolint ignore=DL3041
 RUN echo -e "max_parallel_downloads=8\nretries=50" >> /etc/dnf/dnf.conf && \
@@ -51,8 +54,11 @@ WORKDIR /boost
 RUN wget -nv https://sourceforge.net/projects/boost/files/boost/1.68.0/boost_1_68_0.tar.gz && \
 	if [ "$VERBOSE_LOGS" == "ON" ] ; then export BVERBOSE="-d+2" ; else export BVERBOSE="" ; fi && \
 	tar xf boost_1_68_0.tar.gz && cd boost_1_68_0 && ./bootstrap.sh && \
-	./b2 -j ${JOBS} cxxstd=17 link=static cxxflags='-fPIC' cflags='-fPIC' \
-		--with-chrono --with-date_time --with-filesystem \
+	./b2 -j ${JOBS} cxxstd=17 link=static variant=release \
+                cxxflags="-fPIC $LTO_CXX_FLAGS" \
+                cflags="-fPIC $LTO_CXX_FLAGS" \
+                linkflags="$LTO_LD_FLAGS" \
+                --with-chrono --with-date_time --with-filesystem \
 		--with-program_options --with-system \
 		--with-random --with-thread --with-atomic --with-regex \
 		--with-log --with-locale "$BVERBOSE" \
@@ -65,7 +71,9 @@ COPY third_party/pugixml /ovms/third_party/pugixml
 RUN git clone -b v1.13 https://github.com/zeux/pugixml && \
     cd pugixml && \
     patch -p1 < /ovms/third_party/pugixml/pugixml_v1.13_flags.patch && \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_VERBOSE_MAKEFILE=${VERBOSE_LOGS} && \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_VERBOSE_MAKEFILE=${VERBOSE_LOGS} \
+    -DCMAKE_CXX_FLAGS="${LTO_CXX_FLAGS}" \
+    -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" && \
     make all -j ${JOBS} && \
     cp -P libpugixml.so* /usr/lib64/
 
@@ -79,10 +87,10 @@ RUN git clone --recurse-submodules --depth 1 --branch v2.10.16 https://github.co
     patch -d /azure/azure-storage-cpp/ -p1 </ovms/third_party/azure/azure_sdk.patch
 
 WORKDIR /azure/cpprestsdk/Release/build.release
-RUN cmake .. -DCMAKE_VERBOSE_MAKEFILE=${VERBOSE_LOGS} -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DBoost_USE_STATIC_RUNTIME=ON -DBoost_USE_STATIC_LIBS=ON -DWERROR=OFF -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF && make --jobs=$JOBS install
+RUN cmake .. -DCMAKE_VERBOSE_MAKEFILE=${VERBOSE_LOGS} -DCMAKE_CXX_FLAGS="-fPIC ${LTO_CXX_FLAGS}" -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DBoost_USE_STATIC_RUNTIME=ON -DBoost_USE_STATIC_LIBS=ON -DWERROR=OFF -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF && make --jobs=$JOBS install
 
 WORKDIR /azure/azure-storage-cpp/Microsoft.WindowsAzure.Storage/build.release
-RUN CASABLANCA_DIR=/azure/cpprestsdk cmake .. -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DBoost_USE_STATIC_RUNTIME=ON -DBoost_USE_STATIC_LIBS=ON -DCMAKE_VERBOSE_MAKEFILE=${VERBOSE_LOGS} && make --jobs=$JOBS && make --jobs=$JOBS install
+RUN CASABLANCA_DIR=/azure/cpprestsdk cmake .. -DCMAKE_CXX_FLAGS="-fPIC ${LTO_CXX_FLAGS}" -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DBoost_USE_STATIC_RUNTIME=ON -DBoost_USE_STATIC_LIBS=ON -DCMAKE_VERBOSE_MAKEFILE=${VERBOSE_LOGS} && make --jobs=$JOBS && make --jobs=$JOBS install
 ####### End of Azure SDK
 
 ####### Build OpenCV
@@ -94,6 +102,8 @@ RUN if [ "$VERBOSE_LOGS" == "ON" ] ; then export VERBOSE=1 ; fi && ./install_ope
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 FROM base_build as build
 ARG BASE_IMAGE
+ARG VERBOSE_LOGS=OFF
+ARG LTO_ENABLE=OFF
 
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
@@ -164,9 +174,12 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
 # hadolint ignore=DL3003
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; git clone https://github.com/$ov_source_org/openvino.git /openvino && cd /openvino && git checkout $ov_source_branch && git submodule update --init --recursive
 RUN if [ "$ov_use_binary" == "0" ]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"py_off"* ]]; then true ; else exit 0 ; fi ; pip3 install --no-cache-dir -r /openvino/src/bindings/python/wheel/requirements-dev.txt
+WORKDIR /openvino
+COPY openvino-lto.patch .
+RUN if [ "$ov_use_binary" == "0" ]; then patch -p1 < openvino-lto.patch ; fi
 WORKDIR /openvino/build
-RUN if [ "$ov_use_binary" == "0" ] && [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_PYTHON=ON -DENABLE_INTEL_NPU=OFF -DENABLE_SAMPLES=0 -DNGRAPH_USE_CXX_ABI=1 -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=parentheses "  ..
-RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; cmake -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_SAMPLES=0 -DENABLE_INTEL_NPU=OFF -DNGRAPH_USE_CXX_ABI=1 -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=parentheses " ..
+RUN if [ "$ov_use_binary" == "0" ] && [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_LTO=${LTO_ENABLE} -DENABLE_PYTHON=ON -DENABLE_INTEL_NPU=OFF -DENABLE_SAMPLES=0 -DNGRAPH_USE_CXX_ABI=1 -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=parentheses ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" ..
+RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; cmake -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_LTO=${LTO_ENABLE} -DENABLE_SAMPLES=0 -DENABLE_INTEL_NPU=OFF -DNGRAPH_USE_CXX_ABI=1 -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=parentheses ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" ..
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; make --jobs=$JOBS
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; make install
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; \
@@ -213,7 +226,7 @@ ARG ov_tokenizers_branch=master
 # hadolint ignore=DL3003
 RUN git clone https://github.com/openvinotoolkit/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout $ov_tokenizers_branch && git submodule update --init --recursive
 WORKDIR /openvino_tokenizers/build
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}"  && cmake --build . --parallel $JOBS ; cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DCMAKE_CXX_FLAGS=" ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" && cmake --build . --parallel $JOBS ; cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
 
 # Build OpenVINO Model Server
 WORKDIR /ovms
@@ -311,6 +324,7 @@ FROM $BUILD_IMAGE as capi-build
 # C api shared library
 ARG CAPI_FLAGS="--strip=always  --config=mp_off_py_off --//:distro=redhat"
 ARG JOBS=40
+ARG LTO_ENABLE=OFF
 RUN bazel build --jobs $JOBS ${CAPI_FLAGS} //src:ovms_shared
 
 # C api app with bazel
@@ -322,7 +336,7 @@ RUN bazel build --jobs=$JOBS ${CAPI_FLAGS} //src:capi_benchmark && ./bazel-bin/s
 # C-api C/C++ app with gcc
 COPY MakefileCapi /ovms/
 RUN make -f MakefileCapi cpp CAPI_FLAGS="${CAPI_FLAGS}" && \
-    make -f MakefileCapi c CAPI_FLAGSs="${CAPI_FLAGS}"
+    make -f MakefileCapi c CAPI_FLAGS="${CAPI_FLAGS}"
 
 RUN mkdir -p /ovms_release/lib/ ; find /ovms/bazel-out/k8-*/bin -iname 'libovms_shared.so'  -exec cp -v {} /ovms_release/lib/ \;
 
@@ -399,5 +413,14 @@ COPY --from=build /usr/local/lib64/python3.*/site-packages/MarkupSafe-3.0.2.dist
 COPY --from=build /usr/local/lib64/python3.*/site-packages/markupsafe /ovms/python_deps/markupsafe
 
 COPY --from=pkg /licenses /licenses
+
+# Setup Python Demos Environment
+COPY demos/python_demos/requirements.txt .
+RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; \
+	else export DNF_TOOL=microdnf ; fi ; \
+	$DNF_TOOL install -y python3-pip git ; $DNF_TOOL clean all ; \
+	pip3 install --no-cache-dir -r requirements.txt ; \
+	rm -f requirements.txt
+
 USER ovms
 ENTRYPOINT ["/ovms/bin/ovms"]

--- a/openvino-lto.patch
+++ b/openvino-lto.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2187deb8e8..1bdb5800c1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -64,7 +64,7 @@ include(cmake/dependencies.cmake)
+ if(ENABLE_COVERAGE)
+     include(cmake/coverage.cmake)
+ endif()
+-
++set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
+ if(APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET AND
+     CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.15)
+     message(FATAL_ERROR "OpenVINO requires MACOSX_DEPLOYMENT_TARGET at least 10.15, specified ${CMAKE_OSX_DEPLOYMENT_TARGET}")
+diff --git a/src/frontends/common/CMakeLists.txt b/src/frontends/common/CMakeLists.txt
+index e4d2fe63e1..bb05f64847 100644
+--- a/src/frontends/common/CMakeLists.txt
++++ b/src/frontends/common/CMakeLists.txt
+@@ -52,7 +52,7 @@ target_link_libraries(${TARGET_NAME}_obj PRIVATE openvino::util openvino::core::
+ 
+ # TODO: fix lto
+ set_target_properties(${TARGET_NAME}_obj PROPERTIES
+-    INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
++    INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
+ 
+ set(FRONTEND_LIB_SUFFIX "${FRONTEND_NAME_SUFFIX}${OV_BUILD_POSTFIX}")
+ if(APPLE)
+diff --git a/thirdparty/protobuf/CMakeLists.txt b/thirdparty/protobuf/CMakeLists.txt
+index a16bd56d11..ce788eed4c 100644
+--- a/thirdparty/protobuf/CMakeLists.txt
++++ b/thirdparty/protobuf/CMakeLists.txt
+@@ -63,7 +63,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG OR OV_COMPILER_IS_INTEL_LLVM
+             CXX_VISIBILITY_PRESET default
+             C_VISIBILITY_PRESET default
+             VISIBILITY_INLINES_HIDDEN OFF
+-            INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
++            INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
+     endif()
+     ov_disable_all_warnings(${_protoc_libs} libprotobuf-lite)
+     set_target_properties(libprotobuf-lite PROPERTIES

--- a/third_party/opencv/opencv_cmake_flags.txt
+++ b/third_party/opencv/opencv_cmake_flags.txt
@@ -1,6 +1,7 @@
 -D BUILD_LIST=core,improc,imgcodecs,calib3d,features2d,highgui,imgproc,video,videoio,optflow \
 -D OPENCV_EXTRA_MODULES_PATH=/opt/opencv_contrib_repo/modules \
 -D CMAKE_BUILD_TYPE=Release \
+-D ENABLE_LTO=${LTO_ENABLE} \
 -D CMAKE_INSTALL_PREFIX=/opt/opencv \
 -D OPENCV_LIB_INSTALL_PATH=lib \
 -D BUILD_TESTS=OFF \


### PR DESCRIPTION
### 🛠 Summary
Jira [RHOAIENG-6290](https://issues.redhat.com//browse/RHOAIENG-6290)

This updates the build for 2.19 to the 2025.0 release which drops
CUDA support.
    
This adds Link Time Optimization (LTO) to improve the overall performance.
This pushes LTO into dependencies and the main build. It does this by adding
3 ARGS that can be controlled by passing environmental varibles to the
build: LTO_ENABLE, LTO_CXX_FLAGS and LTO_LD_FLAGS. LTO_LD_FLAGS defaults
to "-Wl,-z,relro" which is a noop since it's hardcoded in the RHEL compiler.

The Boost build is also updated to pass LTO and additional flags to the
build. It also adds 'variant' to the build so it's optimized. This also
updates opencv to use LTO.
    
In the area where OpenVino is being built, this also adds LTO_CXX_FLAGS and
LTO_LD_FLAGS to the cmake because using LTO_CXX_FLAGS also can contain
additional directives such as -march but also because
CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE doesn't reach all places. (Maybe
the build type info is not being used.) It's for this same reason that we
pass these to the tokenizer build.
