### PR TITLE
Constrain setuptools

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -176,7 +176,8 @@ RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; git clone ht
 RUN if [ "$ov_use_binary" == "0" ]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"py_off"* ]]; then true ; else exit 0 ; fi ; pip3 install --no-cache-dir -r /openvino/src/bindings/python/wheel/requirements-dev.txt
 WORKDIR /openvino
 COPY openvino-lto.patch .
-RUN if [ "$ov_use_binary" == "0" ]; then patch -p1 < openvino-lto.patch ; fi
+COPY setup-tools.patch .
+RUN if [ "$ov_use_binary" == "0" ]; then patch -p1 < openvino-lto.patch ; patch -p1 < setup-tools.patch ; fi
 WORKDIR /openvino/build
 RUN if [ "$ov_use_binary" == "0" ] && [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_LTO=${LTO_ENABLE} -DENABLE_PYTHON=ON -DENABLE_INTEL_NPU=OFF -DENABLE_SAMPLES=0 -DNGRAPH_USE_CXX_ABI=1 -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=parentheses ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" ..
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; cmake -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_LTO=${LTO_ENABLE} -DENABLE_SAMPLES=0 -DENABLE_INTEL_NPU=OFF -DNGRAPH_USE_CXX_ABI=1 -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=parentheses ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" ..

--- a/setup-tools.patch
+++ b/setup-tools.patch
@@ -1,0 +1,12 @@
+diff --git a/src/bindings/python/constraints.txt b/src/bindings/python/constraints.txt
+--- a/src/bindings/python/constraints.txt
++++ b/src/bindings/python/constraints.txt
+@@ -10,7 +10,7 @@ pytest-timeout==2.3.1
+ # Python bindings
+ build<1.3
+ pygments>=2.8.1
+-setuptools>=70.1,<75.8
++setuptools>=75.8,<75.9
+ sympy>=1.10
+ wheel>=0.38.1
+ patchelf<=0.17.2.1


### PR DESCRIPTION
Something has changed to where OVMS that built last week does not build this week. This was determined to be a bad version of setuptools being used to build the ovms wheel. This patch constrains the version selection more tightly to one that works.

Jira [RHOAIENG-21965](https://issues.redhat.com/browse/RHOAIENG-21965)