### PR TITLE
Revert transformers update

### DIFF
--- a/demos/python_demos/clip_image_classification/download_model_requirements.txt
+++ b/demos/python_demos/clip_image_classification/download_model_requirements.txt
@@ -3,6 +3,6 @@
 --pre
 openvino==2025.0.*
 numpy<2.0
-transformers==4.48
+transformers==4.40.2
 pillow==10.3.0
 torch==2.2.0+cpu

--- a/demos/python_demos/requirements.txt
+++ b/demos/python_demos/requirements.txt
@@ -7,7 +7,7 @@ onnx==1.17.0
 pillow==10.3.0
 optimum[diffusers]==1.17.1
 tritonclient[grpc]==2.51.0  # Required to use batch string serialization/deserialization (4byte length prepend)
-transformers==4.48
+transformers==4.40
 diffusers==0.26.3
 datasets==2.18.0
 numpy<2.0


### PR DESCRIPTION
### 🛠 Summary
This commit reverts the update of the transformers package. The problem
is that the dependencies of OpenVino, Intel Optimum, and transformers
is tightly linked. When updating just the transformers package, it
causes a traceback because transformers adds an API that Intel Optimum
doesn't support in the pinned version. A future release of Intel Optimum
will be updated to support the new API. Until then we need to wait.
