### PR TITLE
Add build-args.conf file for buildah

### DIFF
--- a/.konflux/build-args.conf
+++ b/.konflux/build-args.conf
@@ -1,0 +1,36 @@
+# Base images
+BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:9.6
+RELEASE_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal:9.6
+
+# Logging/tests
+VERBOSE_LOGS=ON
+RUN_TESTS=ON
+CHECK_COVERAGE=0
+
+# Distro/GPU
+BASE_OS=redhat
+GPU=1
+ov_use_binary=0
+
+# Versions / LTO
+INSTALL_DRIVER_VERSION=24.52.32224
+LTO_ENABLE=ON
+LTO_CXX_FLAGS=-flto=auto -ffat-lto-objects -march=haswell
+LTO_LD_FLAGS=-flto=auto -ffat-lto-objects -Wl,-plugin-opt=-march=haswell
+
+# Source/branch
+SOURCE=openvinotoolkit
+BRANCH=releases/2025/2
+ov_source_org=openvinotoolkit
+ov_contrib_org=openvinotoolkit
+ov_source_branch=releases/2025/2
+ov_contrib_branch=releases/2025/2
+ov_tokenizers_branch=releases/2025/2
+
+# Parallelism
+JOBS=30
+
+# Bazel flags (no quotes, entire value after the '=')
+debug_bazel_flags=--strip=always --define MEDIAPIPE_DISABLE=0 --define PYTHON_DISABLE=0 --//:distro=redhat --local_ram_resources=23552 --local_cpu_resources=28 --verbose_failures --subcommands --config=mp_on_py_on
+CAPI_FLAGS=--strip=always --config=mp_off_py_off --//:distro=redhat --local_ram_resources=23552 --local_cpu_resources=30 --verbose_failures --subcommands
+


### PR DESCRIPTION
Add build-args.conf file for buildah
    
It is possible to pass arguments to buildah which is used to build
container images in Konflux. The Konflux buildah tasks accept
BUILD_ARGS parameter that allows passing build arguments to the
underlying buildah command through --build-arg-file flag.
    
This file contains the build options for 2025.2.1.
