### PR TITLE
Updating konflux integration tests workflow to trigger on check_run events

### DIFF
--- a/.github/workflows/integration-tests-konflux.yml
+++ b/.github/workflows/integration-tests-konflux.yml
@@ -1,8 +1,9 @@
 name: Integration Tests - Konflux
 
 on:
-  # Trigger when a PR build status event is posted by Konflux
-  status:
+  # Trigger when a PR build check_run event is posted by Konflux
+  check_run:
+    types: [completed]
   # Allow manual trigger with custom image tag
   workflow_dispatch:
     inputs:
@@ -24,12 +25,15 @@ jobs:
   setup:
     name: Determine Image Tag
     runs-on: ubuntu-latest
-    # Only run for workflow_dispatch or relevant status events
+    # Only run for workflow_dispatch or relevant check_run events
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'status' &&
-       github.event.state == 'success' &&
-       github.event.context == 'Red Hat Konflux / openvino-model-server-on-pull-request')
+      (
+        github.event_name == 'check_run' &&
+        github.event.check_run.app.slug == 'red-hat-konflux' &&
+        github.event.check_run.conclusion == 'success' &&
+        github.event.check_run.name == 'Red Hat Konflux / openvino-model-server-on-pull-request'
+      )
     outputs:
       image_tag: ${{ steps.set_image_tag.outputs.image_tag }}
       source_ref: ${{ steps.set_source_ref.outputs.source_ref }}
@@ -40,7 +44,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             TAG="${{ github.event.inputs.image_tag }}"
           else
-            TAG="odh-pr-${{ github.event.sha }}"
+            TAG="odh-pr-${{ github.event.check_run.head_sha }}"
           fi
           echo "image_tag=${TAG}" >> $GITHUB_OUTPUT
           echo "Image tag: ${TAG}"
@@ -50,10 +54,22 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             REF="${{ github.event.inputs.source_ref }}"
           else
-            REF="${{ github.event.sha }}"
+            REF="${{ github.event.check_run.head_sha }}"
           fi
           echo "source_ref=${REF}" >> $GITHUB_OUTPUT
           echo "Source ref: ${REF}"
+      - name: Post setup failure statuses
+        if: github.event_name == 'check_run' && failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for context in "File Integrity Test" "Python Clients Test" "Latency Performance Test" "Throughput Performance Test" "Functional Tests"; do
+            gh api repos/${{ github.repository }}/statuses/${{ github.event.check_run.head_sha }} \
+              -f state=failure \
+              -f context="$context" \
+              -f description="Setup failed - cannot run tests" \
+              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          done
 
   # Pull the image
   pull-image:
@@ -76,16 +92,28 @@ jobs:
           name: model-server-image
           path: model-server-image.tar.gz
           retention-days: 1
+      - name: Post image pull failure statuses
+        if: github.event_name == 'check_run' && failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          FULL_IMAGE="quay.io/opendatahub/openvino_model_server:${{ needs.setup.outputs.image_tag }}"
+          for context in "File Integrity Test" "Python Clients Test" "Latency Performance Test" "Throughput Performance Test" "Functional Tests"; do
+            gh api repos/${{ github.repository }}/statuses/${{ needs.setup.outputs.source_ref }} \
+              -f state=failure \
+              -f context="$context" \
+              -f description="Failed to pull image: ${FULL_IMAGE}" \
+              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          done
 
   # File integrity test
   file-integrity:
     name: File Integrity Test
     runs-on: ubuntu-latest
     needs: [setup, pull-image]
-    if: always() && needs.setup.result == 'success'
     steps:
       - name: Post pending status to commit
-        if: github.event_name == 'status'
+        if: github.event_name == 'check_run'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -109,7 +137,7 @@ jobs:
         run: |
           make run_lib_files_test
       - name: Post success status to commit
-        if: github.event_name == 'status' && success()
+        if: github.event_name == 'check_run' && success()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -119,7 +147,7 @@ jobs:
             -f description="File integrity tests passed" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: Post failure status to commit
-        if: github.event_name == 'status' && failure()
+        if: github.event_name == 'check_run' && failure()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -134,10 +162,9 @@ jobs:
     name: Python Clients Test
     runs-on: ubuntu-latest
     needs: [setup, pull-image]
-    if: always() && needs.setup.result == 'success'
     steps:
       - name: Post pending status to commit
-        if: github.event_name == 'status'
+        if: github.event_name == 'check_run'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -161,7 +188,7 @@ jobs:
         run: |
           make test_python_clients
       - name: Post success status to commit
-        if: github.event_name == 'status' && success()
+        if: github.event_name == 'check_run' && success()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -171,7 +198,7 @@ jobs:
             -f description="Python client tests passed" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: Post failure status to commit
-        if: github.event_name == 'status' && failure()
+        if: github.event_name == 'check_run' && failure()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -186,10 +213,9 @@ jobs:
     name: Latency Performance Test
     runs-on: ubuntu-latest
     needs: [setup, pull-image]
-    if: always() && needs.setup.result == 'success'
     steps:
       - name: Post pending status to commit
-        if: github.event_name == 'status'
+        if: github.event_name == 'check_run'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -217,7 +243,7 @@ jobs:
         run: |
           make test_perf
       - name: Post success status to commit
-        if: github.event_name == 'status' && success()
+        if: github.event_name == 'check_run' && success()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -227,7 +253,7 @@ jobs:
             -f description="Latency tests passed" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: Post failure status to commit
-        if: github.event_name == 'status' && failure()
+        if: github.event_name == 'check_run' && failure()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -242,10 +268,9 @@ jobs:
     name: Throughput Performance Test
     runs-on: ubuntu-latest
     needs: [setup, pull-image]
-    if: always() && needs.setup.result == 'success'
     steps:
       - name: Post pending status to commit
-        if: github.event_name == 'status'
+        if: github.event_name == 'check_run'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -273,7 +298,7 @@ jobs:
         run: |
           make test_throughput
       - name: Post success status to commit
-        if: github.event_name == 'status' && success()
+        if: github.event_name == 'check_run' && success()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -283,7 +308,7 @@ jobs:
             -f description="Throughput tests passed" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: Post failure status to commit
-        if: github.event_name == 'status' && failure()
+        if: github.event_name == 'check_run' && failure()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -298,10 +323,9 @@ jobs:
     name: Functional Tests
     runs-on: ubuntu-latest
     needs: [setup, pull-image]
-    if: always() && needs.setup.result == 'success'
     steps:
       - name: Post pending status to commit
-        if: github.event_name == 'status'
+        if: github.event_name == 'check_run'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -331,7 +355,7 @@ jobs:
         run: |
           make test_functional
       - name: Post success status to commit
-        if: github.event_name == 'status' && success()
+        if: github.event_name == 'check_run' && success()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -341,7 +365,7 @@ jobs:
             -f description="Functional tests passed" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: Post failure status to commit
-        if: github.event_name == 'status' && failure()
+        if: github.event_name == 'check_run' && failure()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
### 🛠 Summary
Unlike openshift-ci, which posts status events for image builds, konflux will post check_run events. These event types require different integration with the github api to trigger workflows. This PR makes the necessary updates to the `Integration Tests - Konflux` workflow to properly trigger integration test execution on the check_run events posted by konflux builds.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration testing workflow to enhance reliability and error reporting for Konflux integration, improving visibility into test failures and setup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->