### PR TITLE
Fix Python Client Tests on Release 2026.1

### DIFF
--- a/tests/python/Dockerfile
+++ b/tests/python/Dockerfile
@@ -19,7 +19,7 @@ env DEBIAN_FRONTEND=noninteractive
 run apt-get update && apt-get install -y git software-properties-common && add-apt-repository ppa:deadsnakes/ppa && apt-get update && apt-get install -y \
 python3.9 python3.10 python3.11 python3.12 python3.13 \
 python3.9-distutils python3.10-distutils python3.11-distutils \
-python3.12-dev python3.13-dev \
+python3.9-dev python3.10-dev python3.11-dev python3.12-dev python3.13-dev \
 python3.9-venv python3.10-venv python3.11-venv python3.12-venv python3.13-venv \
 python3-pip
 run pip install invoke

--- a/tests/python/tasks.py
+++ b/tests/python/tasks.py
@@ -15,8 +15,7 @@
 #
 from invoke import task
 
-supported_clients = {"ovmsclient":["3.9","3.10","3.11","3.12","3.13"],
-                     "kserve-api":["3.9","3.10","3.11","3.12","3.13"],
+supported_clients = {"kserve-api":["3.9","3.10","3.11","3.12","3.13"],
                      "tensorflow-serving-api":["3.9","3.10","3.11","3.12"]}
 
 @task
@@ -48,9 +47,6 @@ def test(c, rest=8000, grpc=9000, verbose=False, fastFail=False):
                             c.run(f". .venv{client}{v}/bin/activate && python{v} grpc_infer_binary_resnet.py --grpc_port {grpc} --images_list ../../resnet_input_images.txt --input_name map/TensorArrayStack/TensorArrayGatherV3 --output_name softmax_tensor:0 --model_name resnet", hide=not(verbose))
                         if client == "tensorflow-serving-api":
                             c.run(f". .venv{client}{v}/bin/activate && python{v} grpc_predict_binary_resnet.py --grpc_address localhost --model_name resnet --input_name map/TensorArrayStack/TensorArrayGatherV3 --output_name softmax_tensor:0 --grpc_port {grpc} --images ../../resnet_input_images.txt", hide=not(verbose))
-                        if client == "ovmsclient":
-                            c.run(f". .venv{client}{v}/bin/activate && python{v} grpc_predict_resnet.py --images_numpy ../../imgs_nhwc.npy --model_name resnet --service_url localhost:{grpc}", hide=not(verbose))
-                            c.run(f". .venv{client}{v}/bin/activate && python{v} http_predict_resnet.py --images_numpy ../../imgs_nhwc.npy --model_name resnet --service_url localhost:{rest}", hide=not(verbose))
                         c.run("echo OK")
                     except:
                         c.run("echo FAIL")


### PR DESCRIPTION
### 🛠 Summary
Python client tests are currently broken on the `2026.1-release branch`.

This PR fixes the tests by:
1. Properly including dependencies for _all_ python versions used in the tests.
2. Removing ovmsclient from the tests (the client code was removed in this [commit](https://github.com/opendatahub-io/openvino_model_server/commit/f1b1e2def8a637ae6cf9500b18f39e716018728f))

All integration tests now passing:
https://github.com/opendatahub-io/openvino_model_server/actions/runs/25875571730

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``
