### PR TITLE
Update UBI base image version from 9.7 to 9.8

### DIFF
--- a/01-konflux-build-args.patch
+++ b/01-konflux-build-args.patch
@@ -14,8 +14,8 @@ index 0000000000..644f757c52
 +++ b/.konflux/build-args.conf
 @@ -0,0 +1,37 @@
 +# Base images
-+BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:9.7
-+RELEASE_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal:9.7
++BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:9.8
++RELEASE_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:9.8
 +
 +# Logging/tests
 +VERBOSE_LOGS=ON


### PR DESCRIPTION
Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### 🛠 Summary
Update UBI base image version from 9.7 to 9.8

Jira- Link : https://redhat.atlassian.net/browse/RHOAIENG-63311

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

