### PR TITLE
Update 03-rhoai-konflux.patch for 2026.2 release

### DIFF
--- a/03-rhoai-konflux.patch
+++ b/03-rhoai-konflux.patch
@@ -3,68 +3,23 @@ Author: Steve Grubb <ausearch.1@gmail.com>
 Date:   Mon Apr 6 17:44:03 2026 -0400
 
     Updates to the Red Hat Dockerfile for Konflux
-    
-    The konflux build system has trouble in 2 areas.
-    
-    1) The way that konflux/Buildkit works is that it tears down evreything between
-    RUN commands. When bazel runs, it daemonizes and stashes a copy of
-    /etc/resolve.conf in a tmp directory. BuildKit erases that and bazel can no
-    longer download anything. One fix is to put all bazel build commands on
-    the same RUN.
-    
-    2) Konflux causes bazel to do things differently which results in
+
+    Konflux causes bazel to do things differently which results in
     not being able to find libovms_shared.so or capi_benchmark. So,
     it was changed to try to put it in a known spot for searching.
     
     These changes do not affect the build done by Docker or podman.
 
+    Note: In 2026.2, the bazel build consolidation (hunks #1 and #2 from
+    the original patch) is no longer needed because upstream introduced
+    ARG KONFLUX=1 which conditionally skips the prebuild step, and removed
+    the separate @org_tensorflow and release_custom_nodes builds.
+
 diff --git a/Dockerfile.redhat b/Dockerfile.redhat
 index 043e1e73..87ae2331 100644
 --- a/Dockerfile.redhat
 +++ b/Dockerfile.redhat
-@@ -272,17 +272,12 @@ COPY *\.bzl /ovms/
- COPY yarn.lock /ovms/
- COPY package.json /ovms/
- 
--# prebuild dependencies before copying sources
--# hadolint ignore=DL3059
--RUN bazel build --jobs=$JOBS ${debug_bazel_flags} //:ovms_dependencies @com_google_googletest//:gtest
--
- # hadolint ignore=DL3059
- RUN cp -v /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
- 
- COPY src/ /ovms/src/
- 
- # hadolint ignore=DL3059
--RUN bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework
- 
- # Sample CPU Extension
- WORKDIR /ovms/src/example/SampleCpuExtension/
-@@ -309,17 +304,19 @@ ARG minitrace_flags
- RUN bash -c "sed -i -e 's|REPLACE_PROJECT_VERSION|${PROJECT_VERSION}|g' /ovms/src/version.hpp" && \
-     bash -c "sed -i -e 's|REPLACE_BAZEL_BUILD_FLAGS|${debug_bazel_flags}${minitrace_flags}|g' /ovms/src/version.hpp"
- 
--# Custom Nodes
--RUN bazel build --jobs=$JOBS ${debug_bazel_flags} //src:release_custom_nodes
--
- # OVMS
- ARG OPTIMIZE_BUILDING_TESTS=0
- RUN rm -f /usr/lib64/cmake/OpenSSL/OpenSSLConfig.cmake
- 
- # Builds unit tests together with ovms server in one step
- # It speeds up CI when tests are executed outside of the image building
-+# Konflux build system cuts off network access at times. Build all in 1 shot.
- # hadolint ignore=SC2046
--RUN bazel build --jobs=$JOBS ${debug_bazel_flags} ${minitrace_flags} //src:ovms $(if [ "$OPTIMIZE_BUILDING_TESTS" == "1" ] ; then echo -n //src:ovms_test; fi)
-+RUN bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework && \
-+  bazel build --jobs=$JOBS ${debug_bazel_flags} //:ovms_dependencies @com_google_googletest//:gtest && \
-+  bazel build --jobs=$JOBS ${debug_bazel_flags} //src:release_custom_nodes && \
-+  bazel build --jobs=$JOBS ${debug_bazel_flags} ${minitrace_flags} //src:ovms \
-+  $(if [ "$OPTIMIZE_BUILDING_TESTS" == "1" ] ; then echo -n //src:ovms_test; fi)
- 
- # Tests execution
- COPY ci/check_coverage.bat /ovms/
-@@ -347,14 +344,32 @@ ARG CAPI_FLAGS="--strip=always  --config=mp_off_py_off --//:distro=redhat"
+@@ -341,14 +341,32 @@ ARG CAPI_FLAGS="--strip=always  --config=mp_off_py_off --//:distro=redhat"
  ARG JOBS=40
  ARG LTO_ENABLE=OFF
  WORKDIR /ovms


### PR DESCRIPTION
Remove obsolete hunks #1 and #2 (bazel build consolidation) as upstream 2026.2 introduced ARG KONFLUX=1 which addresses the BuildKit/bazel issue differently. Only the capi-build binary location fix (hunk #3) remains.

Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### 🛠 Summary

JIRA/Issue if applicable.
Describe the changes.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

