### PR TITLE
Apply RHOAI patches for 2026.2 release

### DIFF
--- a/.konflux/build-args.conf
+++ b/.konflux/build-args.conf
@@ -1,0 +1,37 @@
+# Base images
+BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:9.8
+RELEASE_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:9.8
+
+# Logging/tests
+VERBOSE_LOGS=ON
+RUN_TESTS=1
+OPTIMIZE_BUILDING_TESTS=1
+CHECK_COVERAGE=0
+
+# Distro/GPU
+BASE_OS=redhat
+GPU=1
+ov_use_binary=0
+
+# Versions / LTO
+INSTALL_DRIVER_VERSION=25.05.32567
+LTO_ENABLE=ON
+LTO_CXX_FLAGS=-flto=auto -ffat-lto-objects -march=haswell
+LTO_LD_FLAGS=-flto=auto -ffat-lto-objects -Wl,-plugin-opt=-march=haswell
+
+# Source/branch
+SOURCE=opendatahub-io
+BRANCH=releases/2026/2
+ov_source_org=opendatahub-io
+ov_source_branch=releases/2026/2
+ov_tokenizers_org=opendatahub-io
+ov_tokenizers_branch=releases/2026/2
+ov_genai_org=opendatahub-io
+ov_genai_branch=releases/2026/2
+
+# Parallelism
+JOBS=30
+
+# Bazel flags (no quotes, entire value after the '=')
+debug_bazel_flags=--strip=always --define MEDIAPIPE_DISABLE=0 --define PYTHON_DISABLE=0 --//:distro=redhat --local_ram_resources=23552 --local_cpu_resources=28 --verbose_failures --subcommands --config=mp_on_py_on
+CAPI_FLAGS=--strip=always --config=mp_off_py_off --//:distro=redhat --local_ram_resources=23552 --local_cpu_resources=30 --verbose_failures --subcommands

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -455,3 +455,12 @@ RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; \
 
 USER ovms
 ENTRYPOINT ["/ovms/bin/ovms"]
+
+LABEL name="rhoai/odh-openvino-model-server-rhel9" \
+      com.redhat.component="odh-openvino-model-server-rhel9" \
+      io.k8s.display-name="odh-openvino-model-server-rhel9" \
+      io.k8s.description="OpenVINO Model Server (OVMS) is a high-performance system for serving models." \
+      description="OpenVINO Model Server (OVMS) is a high-performance system for serving models." \
+      summary="OpenVINO Model Server (OVMS) is a high-performance system for serving models." \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf" \
+	  vendor="Red Hat, Inc."

--- a/demos/python_demos/base-requirements.txt
+++ b/demos/python_demos/base-requirements.txt
@@ -1,0 +1,4 @@
+--extra-index-url "https://download.pytorch.org/whl/cpu"
+optimum-intel@git+https://github.com/huggingface/optimum-intel.git
+nncf>=2.11.0
+transformers<=4.53


### PR DESCRIPTION
Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### 🛠 Summary
Apply RHOAI patches for 2026.2 release
- Add .konflux/build-args.conf with 2026/2 branch references
- Add Python demo dependencies (optimum-intel, nncf, transformers)
- Fix Konflux capi-build binary location issue
- Add Dockerfile.konflux with RHOAI labels


Jira-Link : https://redhat.atlassian.net/browse/RHOAIENG-63311
[ovms-pytest.html](https://github.com/user-attachments/files/29703508/ovms-pytest.html)

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

