### PR TITLE
feat: Add multi-arch support for s390x and ppc64le

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -1,0 +1,107 @@
+name: Multi-Arch Build
+
+on:
+  push:
+    branches:
+      - multiarch/*
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: opendatahub/openvino_model_server
+
+jobs:
+  build-multiarch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/s390x,linux/ppc64le
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+            network=host
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.redhat
+          platforms: linux/amd64,linux/s390x,linux/ppc64le
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_OS=redhat
+            GPU=0
+            JOBS=8
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify multi-arch manifest
+        if: github.event_name != 'pull_request'
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+
+          # Verify all three architectures are present
+          MANIFEST=$(docker buildx imagetools inspect --raw ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }})
+          echo "$MANIFEST" | jq -r '.manifests[].platform | "\(.os)/\(.architecture)"' | sort
+
+          # Check that we have exactly 3 architectures
+          ARCH_COUNT=$(echo "$MANIFEST" | jq -r '.manifests[].platform.architecture' | wc -l)
+          if [ "$ARCH_COUNT" -ne 3 ]; then
+            echo "ERROR: Expected 3 architectures but found $ARCH_COUNT"
+            exit 1
+          fi
+
+          # Verify each architecture is present
+          for arch in amd64 s390x ppc64le; do
+            if ! echo "$MANIFEST" | jq -e ".manifests[] | select(.platform.architecture == \"$arch\")" > /dev/null; then
+              echo "ERROR: Architecture $arch not found in manifest"
+              exit 1
+            fi
+            echo "✓ Architecture $arch present"
+          done
+
+      - name: Test pull for each architecture
+        if: github.event_name != 'pull_request'
+        run: |
+          for arch in amd64 s390x ppc64le; do
+            echo "Testing pull for $arch..."
+            docker pull --platform linux/$arch \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            echo "✓ Successfully pulled $arch image"
+          done

--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -18,26 +18,27 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf  # v3.2.0
         with:
           platforms: linux/amd64,linux/s390x,linux/ppc64le
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349  # v3.7.1
         with:
           driver-opts: |
-            image=moby/buildkit:latest
+            image=moby/buildkit:v0.17.3
             network=host
 
       - name: Login to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}
@@ -45,7 +46,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81  # v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -55,7 +56,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push multi-arch image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75  # v6.9.0
         with:
           context: .
           file: Dockerfile.redhat
@@ -65,7 +66,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BASE_OS=redhat
-            GPU=0
             JOBS=8
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -1,0 +1,323 @@
+# OVMS Multi-Architecture Build Guide
+
+## Overview
+
+This guide helps you build OpenVINO Model Server (OVMS) with multi-architecture support for amd64, s390x, and ppc64le.
+
+## Prerequisites
+
+### Hardware Requirements
+
+**Minimum recommended (for single-arch amd64 build):**
+- **Disk Space**: 50GB free (build artifacts + Docker layers)
+- **RAM**: 16GB (8GB minimum, but builds may fail with OOM)
+- **CPU**: 4 cores minimum (8+ cores recommended)
+- **Build Time**: 2-4 hours for full build
+
+**For multi-arch build (all 3 architectures):**
+- **Disk Space**: 100GB free
+- **RAM**: 16GB minimum
+- **CPU**: 8+ cores highly recommended
+- **Build Time**: 6-12 hours total (with QEMU emulation)
+
+### Software Requirements
+
+1. **Docker Desktop** (or Docker Engine + buildx plugin)
+   - Version 20.10+ with buildx support
+   - Enable containerd image store for better performance
+
+2. **Buildx Builder** with multi-platform support
+   ```bash
+   docker buildx create --name ovms-multiarch --driver docker-container --use
+   docker buildx inspect ovms-multiarch --bootstrap
+   ```
+
+3. **Git** for source checkout
+
+## Quick Start
+
+### Option 1: Single Architecture Build (Recommended for Testing)
+
+Build just for your current architecture to verify everything works:
+
+```bash
+# Build only amd64
+make docker_build BASE_OS=redhat DIST_OS=redhat
+
+# Or build for a specific single arch with buildx
+docker buildx build \
+  --builder ovms-multiarch \
+  --platform linux/amd64 \
+  --file Dockerfile.redhat \
+  --build-arg BASE_OS=redhat \
+  --build-arg JOBS=8 \
+  --load \
+  --tag ovms:test-amd64 \
+  .
+```
+
+### Option 2: Multi-Arch Build (Production)
+
+```bash
+# Build for all architectures and push to registry
+make docker_build_multiarch \
+  BASE_OS=redhat \
+  DIST_OS=redhat \
+  OVMS_CPP_DOCKER_IMAGE=quay.io/yourusername/openvino_model_server \
+  OVMS_CPP_IMAGE_TAG=v2026.3-multiarch
+```
+
+### Option 3: Per-Architecture Build (For Debugging)
+
+Build each architecture separately:
+
+```bash
+# Build each separately
+for arch in amd64 s390x ppc64le; do
+  docker buildx build \
+    --builder ovms-multiarch \
+    --platform linux/$arch \
+    --file Dockerfile.redhat \
+    --build-arg BASE_OS=redhat \
+    --build-arg GPU=0 \
+    --build-arg JOBS=8 \
+    --tag ovms:test-$arch \
+    --load \
+    .
+done
+```
+
+## Build Optimization Tips
+
+### 1. Use Build Cache
+
+Docker buildx maintains a build cache. Leverage it:
+
+```bash
+docker buildx build \
+  --cache-from type=local,src=/tmp/.buildx-cache \
+  --cache-to type=local,dest=/tmp/.buildx-cache \
+  ...
+```
+
+### 2. Reduce Parallel Jobs for Memory-Constrained Systems
+
+The `JOBS` parameter controls parallel compilation:
+
+```bash
+# For systems with 8GB RAM
+--build-arg JOBS=4
+
+# For systems with 16GB+ RAM
+--build-arg JOBS=8
+```
+
+### 3. Build Only What You Need
+
+Skip GPU support for non-x86 or if you don't need it:
+
+```bash
+--build-arg GPU=0
+```
+
+Skip Python bindings if not needed:
+
+```bash
+--build-arg PYTHON_DISABLE=1 --build-arg MEDIAPIPE_DISABLE=1
+```
+
+### 4. Use Stage-Specific Builds
+
+Build up to a specific stage to debug:
+
+```bash
+docker buildx build \
+  --target=base_build \  # or 'build', 'pkg', 'release'
+  ...
+```
+
+## Common Build Issues and Solutions
+
+### Issue 1: "Out of Memory" / Build Killed
+
+**Symptoms:**
+- Build process killed without error
+- Container exits with code 137
+- System becomes unresponsive during build
+
+**Solutions:**
+1. Reduce parallel jobs: `--build-arg JOBS=2`
+2. Increase Docker Desktop memory limit (Settings → Resources → Memory)
+3. Build in stages and clean up between stages:
+   ```bash
+   docker system prune -a -f
+   ```
+
+### Issue 2: "No Space Left on Device"
+
+**Symptoms:**
+- Build fails with disk space errors
+- Docker pull/push fails
+
+**Solutions:**
+1. Clean up Docker:
+   ```bash
+   docker system prune -a -f --volumes
+   docker buildx prune -a -f
+   ```
+2. Increase Docker Desktop disk image size (Settings → Resources → Disk)
+3. Change Docker data directory to a larger drive
+
+### Issue 3: Bazel Build Timeout (s390x/ppc64le)
+
+**Symptoms:**
+- OpenVINO compilation hangs or times out on non-x86 architectures
+
+**Solutions:**
+1. Already implemented in Dockerfile: reduced JOBS to 8 for s390x/ppc64le
+2. If still timing out, manually override:
+   ```bash
+   # Edit Dockerfile.redhat line ~119, change to:
+   echo "export ARCH_JOBS=4" > /tmp/jobs_override.sh
+   ```
+
+### Issue 4: QEMU Emulation is Very Slow
+
+**Symptoms:**
+- s390x/ppc64le builds take 10+ hours
+- System resources underutilized
+
+**Reality Check:**
+- QEMU emulation for cross-arch builds is inherently slow (5-10x slower than native)
+- This is expected behavior, not a bug
+
+**Solutions:**
+1. **Use GitHub Actions** (recommended): Let CI build on GitHub's infrastructure
+2. **Use native hardware**: Build s390x on IBM Z, ppc64le on POWER systems
+3. **Use cloud build services**: 
+   - AWS CodeBuild (supports multi-arch)
+   - Google Cloud Build
+   - Quay.io (auto-builds on push)
+
+### Issue 5: "Cannot connect to Docker daemon"
+
+**Symptoms:**
+- `make docker_build_multiarch` fails immediately
+
+**Solutions:**
+1. Start Docker Desktop: `open -a Docker`
+2. Wait for Docker to fully start (~30 seconds)
+3. Verify: `docker info`
+
+## Recommended Build Strategy
+
+### For Development/Testing
+
+**Don't build locally** - it's time-consuming and resource-intensive.
+
+Instead:
+1. **Push to GitHub**: The multi-arch workflow will build automatically
+2. **Use pre-built images**: Pull from quay.io/opendatahub/openvino_model_server
+3. **Build single-arch only**: Just build amd64 locally for testing
+
+### For Production
+
+**Use CI/CD pipeline:**
+
+1. **GitHub Actions** (already configured in `.github/workflows/multiarch-build.yaml`):
+   - Automatically builds on push to multiarch/* branches
+   - Builds all 3 architectures in parallel
+   - Pushes to Quay.io registry
+   - Verifies manifest integrity
+
+2. **Required secrets** in GitHub repo:
+   - `QUAY_USERNAME`: Your Quay.io username
+   - `QUAY_PASSWORD`: Your Quay.io password or robot token
+
+## Build Time Estimates
+
+Based on GitHub Actions runners (not local QEMU emulation):
+
+| Architecture | Build Time | Notes |
+|--------------|-----------|--------|
+| amd64 | 1-2 hours | Native x86_64 build |
+| s390x | 3-5 hours | QEMU emulation (slow) |
+| ppc64le | 3-5 hours | QEMU emulation (slow) |
+| **Total (parallel)** | **5-6 hours** | GitHub Actions runs in parallel |
+
+## Testing Your Build
+
+### 1. Verify Image Exists
+
+```bash
+docker images | grep ovms
+```
+
+### 2. Run Basic Version Check
+
+```bash
+docker run --rm ovms:test-amd64 --version
+```
+
+### 3. Test Multi-Arch Manifest
+
+```bash
+# Inspect manifest
+docker buildx imagetools inspect quay.io/yourusername/openvino_model_server:v2026.3-multiarch
+
+# Should show all three architectures:
+# - linux/amd64
+# - linux/s390x
+# - linux/ppc64le
+```
+
+### 4. Test Architecture-Specific Pull
+
+```bash
+for arch in amd64 s390x ppc64le; do
+  echo "Testing $arch..."
+  docker pull --platform linux/$arch \
+    quay.io/yourusername/openvino_model_server:v2026.3-multiarch
+done
+```
+
+## What If the Build Still Fails?
+
+### Fallback Option: Use Binary OpenVINO Package
+
+Instead of building OpenVINO from source (which is slow), use pre-built binaries:
+
+```bash
+docker buildx build \
+  --build-arg ov_use_binary=1 \
+  --build-arg DLDT_PACKAGE_URL=<openvino-binary-url> \
+  ...
+```
+
+**Note:** Binary packages may not be available for s390x/ppc64le, so source builds are necessary for those architectures.
+
+### Contact for Help
+
+If you encounter issues not covered here:
+
+1. **Check existing issues**: https://github.com/opendatahub-io/openvino_model_server/issues
+2. **File a new issue** with:
+   - Your system specs (CPU, RAM, OS)
+   - Docker version: `docker version`
+   - Full build log (use `--progress=plain`)
+   - Error messages
+
+## Next Steps
+
+After a successful build:
+
+1. **Update image references** in opendatahub-tests repository
+2. **Run test suite** to verify functionality on each architecture
+3. **Tag release version** and push to production registry
+4. **Update documentation** with new image digest
+
+## Additional Resources
+
+- [Docker Buildx Multi-Platform Docs](https://docs.docker.com/build/building/multi-platform/)
+- [OpenVINO Build Documentation](https://docs.openvino.ai/2025/get-started/install-openvino.html)
+- [OVMS Multi-Arch Implementation Guide](/Users/kpunwatk/opendatahub-tests/OVMS_MULTIARCH_BUILD_GUIDE.md)

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -21,6 +21,8 @@ ARG RELEASE_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
 FROM $BASE_IMAGE as base_build
 ARG BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:9.7
+ARG TARGETARCH
+ARG TARGETPLATFORM
 
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
@@ -104,6 +106,8 @@ RUN if [ "$VERBOSE_LOGS" == "ON" ] ; then export VERBOSE=1 ; fi && OPENCV_VERSIO
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 FROM base_build as build
 ARG BASE_IMAGE
+ARG TARGETARCH
+ARG TARGETPLATFORM
 
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
@@ -111,13 +115,27 @@ ARG JOBS=40
 ARG VERBOSE_LOGS=OFF
 ARG LTO_ENABLE=OFF
 
+# Set architecture-specific JOBS value
+RUN if [ "$TARGETARCH" = "s390x" ] || [ "$TARGETARCH" = "ppc64le" ]; then \
+        echo "export ARCH_JOBS=8" > /tmp/jobs_override.sh; \
+    else \
+        echo "export ARCH_JOBS=${JOBS:-40}" > /tmp/jobs_override.sh; \
+    fi
+
 # hadolint ignore=DL3041
-RUN dnf install -y -d6 \
-            https://vault.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/opencl-headers-2.2-1.20180306gite986688.el8.noarch.rpm \
+RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "x86_64" ] || [ -z "$TARGETARCH" ]; then \
+        OPENCL_PKG="https://vault.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/opencl-headers-2.2-1.20180306gite986688.el8.noarch.rpm"; \
+        LIBGUSB_PKG="libgusb.x86_64"; \
+    else \
+        OPENCL_PKG=""; \
+        LIBGUSB_PKG="libgusb"; \
+    fi && \
+    dnf install -y -d6 \
+            ${OPENCL_PKG:+$OPENCL_PKG} \
             gdb \
             java-11-openjdk-devel \
             tzdata-java \
-            libgusb.x86_64 \
+            $LIBGUSB_PKG \
             libusbx \
             libtool \
             openssl-devel \
@@ -151,11 +169,20 @@ RUN python3.12 --version && python3.12 -m pip install "numpy<2.0.0" "Jinja2==3.1
 # Set up Bazel
 ENV BAZEL_VERSION 6.1.1
 WORKDIR /bazel
-RUN curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
+RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "x86_64" ] || [ -z "$TARGETARCH" ]; then \
+        BAZEL_ARCH="x86_64"; \
+    elif [ "$TARGETARCH" = "s390x" ]; then \
+        BAZEL_ARCH="s390x"; \
+    elif [ "$TARGETARCH" = "ppc64le" ]; then \
+        BAZEL_ARCH="ppc64le"; \
+    else \
+        BAZEL_ARCH="x86_64"; \
+    fi && \
+    curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-${BAZEL_ARCH}.sh && \
     curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -o /bazel/LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE && \
     chmod +x bazel-*.sh && \
-    ./bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
-    rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
+    ./bazel-$BAZEL_VERSION-installer-linux-${BAZEL_ARCH}.sh && \
+    rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-${BAZEL_ARCH}.sh
 
 RUN  dnf install -y https://github.com/linux-test-project/lcov/releases/download/v1.16/lcov-1.16-1.noarch.rpm && dnf clean all
 
@@ -179,6 +206,16 @@ RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && alt
 
 ################### BUILD OPENVINO FROM SOURCE - buildarg ov_use_binary=0  ############################
 ARG SDL_OPS="-Wl,-z,relro,-z,now,-z,noexecstack -fPIE -pie -fstack-protector-strong -fexceptions -fasynchronous-unwind-tables -fcf-protection -fpic -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fno-strict-overflow -Wno-unknown-pragmas -Wno-error=sign-compare -fno-delete-null-pointer-checks -fwrapv -fstack-clash-protection -Wformat -Wformat-security -s -D_GLIBCXX_USE_CXX11_ABI=1 -Wuninitialized"
+
+# Set architecture-specific flags
+RUN if [ "$TARGETARCH" = "s390x" ]; then \
+        echo "export ARCH_CMAKE_FLAGS='-DCMAKE_CXX_FLAGS=-march=z14 -DENABLE_LTO=OFF -DENABLE_INTEL_CPU=OFF -DENABLE_INTEL_GPU=OFF -DENABLE_AUTO=OFF'" > /tmp/arch_flags.sh; \
+    elif [ "$TARGETARCH" = "ppc64le" ]; then \
+        echo "export ARCH_CMAKE_FLAGS='-DCMAKE_CXX_FLAGS=-mcpu=power9 -DENABLE_LTO=OFF -DENABLE_INTEL_CPU=OFF -DENABLE_INTEL_GPU=OFF -DENABLE_AUTO=OFF'" > /tmp/arch_flags.sh; \
+    else \
+        echo "export ARCH_CMAKE_FLAGS=''" > /tmp/arch_flags.sh; \
+    fi
+
 # hadolint ignore=DL3041
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && dnf install -y gflags-devel gflags json-devel fdupes && \
     dnf clean all
@@ -187,10 +224,11 @@ RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; git clone ht
 RUN if [ "$ov_use_binary" == "0" ]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"py_off"* ]]; then true ; else exit 0 ; fi ; pip3.12 install --no-cache-dir -r /openvino/src/bindings/python/wheel/requirements-dev.txt
 WORKDIR /openvino/build
 RUN if [ "$ov_use_binary" == "0" ]; then true ; else exit 0 ; fi ; \
+    source /tmp/arch_flags.sh ; \
     if ! [[ $debug_bazel_flags == *"py_off"* ]]; then \
-        cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_LTO=${LTO_ENABLE} -DENABLE_PYTHON=ON -DENABLE_SAMPLES=0 -DENABLE_INTEL_NPU=OFF -DCMAKE_CXX_FLAGS="  ${SDL_OPS} -Wno-error=parentheses  ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" .. ; \
+        cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_LTO=${LTO_ENABLE} -DENABLE_PYTHON=ON -DENABLE_SAMPLES=0 -DENABLE_INTEL_NPU=OFF -DCMAKE_CXX_FLAGS="  ${SDL_OPS} -Wno-error=parentheses  ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" ${ARCH_CMAKE_FLAGS} .. ; \
     else \
-        cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_LTO=${LTO_ENABLE} -DENABLE_SAMPLES=0 -DENABLE_INTEL_NPU=OFF -DCMAKE_CXX_FLAGS="  ${SDL_OPS} -Wno-error=parentheses ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" .. ; \
+        cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_LTO=${LTO_ENABLE} -DENABLE_SAMPLES=0 -DENABLE_INTEL_NPU=OFF -DCMAKE_CXX_FLAGS="  ${SDL_OPS} -Wno-error=parentheses ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" ${ARCH_CMAKE_FLAGS} .. ; \
     fi && \
     make --jobs=$JOBS && \
     make install
@@ -259,7 +297,13 @@ WORKDIR /ovms
 COPY .bazelrc .user.bazelr[c] .bazelversion WORKSPACE /ovms/
 # since bazel does not have easy way to pass if down the dependencies to have select the sources
 # for libcurl & ssl we hack it this way
-RUN ln -s /usr/lib64 /usr/lib/x86_64-linux-gnu
+RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "x86_64" ] || [ -z "$TARGETARCH" ]; then \
+        ln -s /usr/lib64 /usr/lib/x86_64-linux-gnu; \
+    elif [ "$TARGETARCH" = "s390x" ]; then \
+        ln -s /usr/lib64 /usr/lib/s390x-linux-gnu; \
+    elif [ "$TARGETARCH" = "ppc64le" ]; then \
+        ln -s /usr/lib64 /usr/lib/powerpc64le-linux-gnu; \
+    fi
 COPY external /ovms/external/
 COPY third_party /ovms/third_party
 
@@ -334,6 +378,7 @@ RUN python3.12 -c "import json; m={'PROJECT_VERSION':'${PROJECT_VERSION}','OPENV
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 FROM $BUILD_IMAGE as capi-build
+ARG TARGETARCH
 # C api shared library
 ARG CAPI_FLAGS="--strip=always  --config=mp_off_py_off --//:distro=redhat"
 ARG JOBS=40
@@ -355,6 +400,7 @@ RUN make -f MakefileCapi cpp CAPI_FLAGS="${CAPI_FLAGS}" && \
 RUN mkdir -p /ovms_release/lib/ ; find /ovms/bazel-out/k8-*/bin -iname 'libovms_shared.so'  -exec cp -v {} /ovms_release/lib/ \;
 
 FROM $BUILD_IMAGE as pkg
+ARG TARGETARCH
 
 COPY --from=build /usr/local/bin/patchelf /usr/local/bin/patchelf
 
@@ -372,6 +418,7 @@ RUN mkdir /licenses && ln -s /ovms_release/LICENSE /licenses && ln -s /ovms_rele
 
 
 FROM $RELEASE_BASE_IMAGE as release
+ARG TARGETARCH
 LABEL "name"="OVMS"
 LABEL "vendor"="Intel Corporation"
 LABEL "version"="2026.3.0"
@@ -383,10 +430,15 @@ ARG INSTALL_RPMS_FROM_URL=
 ARG INSTALL_DRIVER_VERSION="24.52.32224"
 ARG GPU=0
 ARG debug_bazel_flags=
+# Force GPU=0 for non-x86 architectures
+RUN if [ "$TARGETARCH" = "s390x" ] || [ "$TARGETARCH" = "ppc64le" ]; then \
+        export GPU=0; \
+    fi
 LABEL bazel-build-flags=${debug_bazel_flags}
 LABEL supported-devices="CPU=1 GPU=${GPU}"
 ARG RELEASE_BASE_IMAGE
 LABEL base-image=${RELEASE_BASE_IMAGE}
+LABEL architecture=${TARGETARCH}
 
 ENV PYTHONPATH=/ovms/lib/python:/ovms/python_deps
 

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -115,13 +115,6 @@ ARG JOBS=40
 ARG VERBOSE_LOGS=OFF
 ARG LTO_ENABLE=OFF
 
-# Set architecture-specific JOBS value
-RUN if [ "$TARGETARCH" = "s390x" ] || [ "$TARGETARCH" = "ppc64le" ]; then \
-        echo "export ARCH_JOBS=8" > /tmp/jobs_override.sh; \
-    else \
-        echo "export ARCH_JOBS=${JOBS:-40}" > /tmp/jobs_override.sh; \
-    fi
-
 # hadolint ignore=DL3041
 RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "x86_64" ] || [ -z "$TARGETARCH" ]; then \
         OPENCL_PKG="https://vault.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/opencl-headers-2.2-1.20180306gite986688.el8.noarch.rpm"; \
@@ -170,19 +163,21 @@ RUN python3.12 --version && python3.12 -m pip install "numpy<2.0.0" "Jinja2==3.1
 ENV BAZEL_VERSION 6.1.1
 WORKDIR /bazel
 RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "x86_64" ] || [ -z "$TARGETARCH" ]; then \
-        BAZEL_ARCH="x86_64"; \
-    elif [ "$TARGETARCH" = "s390x" ]; then \
-        BAZEL_ARCH="s390x"; \
-    elif [ "$TARGETARCH" = "ppc64le" ]; then \
-        BAZEL_ARCH="ppc64le"; \
+        # Use official installer for x86_64
+        curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
+        curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -o /bazel/LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE && \
+        chmod +x bazel-*.sh && \
+        ./bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
+        rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh; \
     else \
-        BAZEL_ARCH="x86_64"; \
-    fi && \
-    curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-${BAZEL_ARCH}.sh && \
-    curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -o /bazel/LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE && \
-    chmod +x bazel-*.sh && \
-    ./bazel-$BAZEL_VERSION-installer-linux-${BAZEL_ARCH}.sh && \
-    rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-${BAZEL_ARCH}.sh
+        # For s390x/ppc64le: use distribution package (pre-built binaries not available)
+        dnf install -y java-11-openjdk-devel unzip zip && \
+        curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-dist.zip && \
+        unzip -q bazel-$BAZEL_VERSION-dist.zip && \
+        env EXTRA_BAZEL_ARGS="--tool_java_runtime_version=local_jdk" bash ./compile.sh && \
+        cp output/bazel /usr/local/bin/ && \
+        cd / && rm -rf /bazel; \
+    fi
 
 RUN  dnf install -y https://github.com/linux-test-project/lcov/releases/download/v1.16/lcov-1.16-1.noarch.rpm && dnf clean all
 
@@ -209,11 +204,14 @@ ARG SDL_OPS="-Wl,-z,relro,-z,now,-z,noexecstack -fPIE -pie -fstack-protector-str
 
 # Set architecture-specific flags
 RUN if [ "$TARGETARCH" = "s390x" ]; then \
-        echo "export ARCH_CMAKE_FLAGS='-DCMAKE_CXX_FLAGS=-march=z14 -DENABLE_LTO=OFF -DENABLE_INTEL_CPU=OFF -DENABLE_INTEL_GPU=OFF -DENABLE_AUTO=OFF'" > /tmp/arch_flags.sh; \
+        echo "export ARCH_CXX_EXTRA='-march=z14'" > /tmp/arch_flags.sh; \
+        echo "export ARCH_CMAKE_EXTRA='-DENABLE_LTO=OFF -DENABLE_INTEL_CPU=OFF -DENABLE_INTEL_GPU=OFF -DENABLE_AUTO=OFF'" >> /tmp/arch_flags.sh; \
     elif [ "$TARGETARCH" = "ppc64le" ]; then \
-        echo "export ARCH_CMAKE_FLAGS='-DCMAKE_CXX_FLAGS=-mcpu=power9 -DENABLE_LTO=OFF -DENABLE_INTEL_CPU=OFF -DENABLE_INTEL_GPU=OFF -DENABLE_AUTO=OFF'" > /tmp/arch_flags.sh; \
+        echo "export ARCH_CXX_EXTRA='-mcpu=power9'" > /tmp/arch_flags.sh; \
+        echo "export ARCH_CMAKE_EXTRA='-DENABLE_LTO=OFF -DENABLE_INTEL_CPU=OFF -DENABLE_INTEL_GPU=OFF -DENABLE_AUTO=OFF'" >> /tmp/arch_flags.sh; \
     else \
-        echo "export ARCH_CMAKE_FLAGS=''" > /tmp/arch_flags.sh; \
+        echo "export ARCH_CXX_EXTRA=''" > /tmp/arch_flags.sh; \
+        echo "export ARCH_CMAKE_EXTRA=''" >> /tmp/arch_flags.sh; \
     fi
 
 # hadolint ignore=DL3041
@@ -226,9 +224,9 @@ WORKDIR /openvino/build
 RUN if [ "$ov_use_binary" == "0" ]; then true ; else exit 0 ; fi ; \
     source /tmp/arch_flags.sh ; \
     if ! [[ $debug_bazel_flags == *"py_off"* ]]; then \
-        cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_LTO=${LTO_ENABLE} -DENABLE_PYTHON=ON -DENABLE_SAMPLES=0 -DENABLE_INTEL_NPU=OFF -DCMAKE_CXX_FLAGS="  ${SDL_OPS} -Wno-error=parentheses  ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" ${ARCH_CMAKE_FLAGS} .. ; \
+        cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_LTO=${LTO_ENABLE} -DENABLE_PYTHON=ON -DENABLE_SAMPLES=0 -DENABLE_INTEL_NPU=OFF -DCMAKE_CXX_FLAGS="${SDL_OPS} -Wno-error=parentheses ${LTO_CXX_FLAGS} ${ARCH_CXX_EXTRA}" -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" ${ARCH_CMAKE_EXTRA} .. ; \
     else \
-        cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_LTO=${LTO_ENABLE} -DENABLE_SAMPLES=0 -DENABLE_INTEL_NPU=OFF -DCMAKE_CXX_FLAGS="  ${SDL_OPS} -Wno-error=parentheses ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" ${ARCH_CMAKE_FLAGS} .. ; \
+        cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_LTO=${LTO_ENABLE} -DENABLE_SAMPLES=0 -DENABLE_INTEL_NPU=OFF -DCMAKE_CXX_FLAGS="${SDL_OPS} -Wno-error=parentheses ${LTO_CXX_FLAGS} ${ARCH_CXX_EXTRA}" -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" ${ARCH_CMAKE_EXTRA} .. ; \
     fi && \
     make --jobs=$JOBS && \
     make install
@@ -428,12 +426,9 @@ LABEL "description"="OpenVINO(TM) Model Server is a solution for serving AI mode
 LABEL "maintainer"="dariusz.trawinski@intel.com"
 ARG INSTALL_RPMS_FROM_URL=
 ARG INSTALL_DRIVER_VERSION="24.52.32224"
+# Default to GPU=0, can be overridden for amd64
 ARG GPU=0
 ARG debug_bazel_flags=
-# Force GPU=0 for non-x86 architectures
-RUN if [ "$TARGETARCH" = "s390x" ] || [ "$TARGETARCH" = "ppc64le" ]; then \
-        export GPU=0; \
-    fi
 LABEL bazel-build-flags=${debug_bazel_flags}
 LABEL supported-devices="CPU=1 GPU=${GPU}"
 ARG RELEASE_BASE_IMAGE

--- a/Makefile
+++ b/Makefile
@@ -705,45 +705,29 @@ docker_build_multiarch:
 	@echo "Building multi-arch OVMS images for linux/amd64,linux/s390x,linux/ppc64le..."
 	docker buildx build \
 		--platform linux/amd64,linux/s390x,linux/ppc64le \
-		--file Dockerfile.$(DIST_OS) \
+		--file "Dockerfile.$(DIST_OS)" \
 		$(BUILD_ARGS) \
-		--build-arg GPU=0 \
-		--tag $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG) \
+		--tag "$(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)" \
 		--push \
 		.
 
 .PHONY: docker_build_per_arch
 docker_build_per_arch:
 	@echo "Building per-arch OVMS images..."
-	# Build amd64
-	docker buildx build --platform linux/amd64 \
-		--file Dockerfile.$(DIST_OS) \
-		$(BUILD_ARGS) \
-		--tag $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-amd64 \
-		--push \
-		.
-
-	# Build s390x
-	docker buildx build --platform linux/s390x \
-		--file Dockerfile.$(DIST_OS) \
-		$(BUILD_ARGS) \
-		--build-arg GPU=0 \
-		--tag $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-s390x \
-		--push \
-		.
-
-	# Build ppc64le
-	docker buildx build --platform linux/ppc64le \
-		--file Dockerfile.$(DIST_OS) \
-		$(BUILD_ARGS) \
-		--build-arg GPU=0 \
-		--tag $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-ppc64le \
-		--push \
-		.
-
-	# Create manifest list
+	@for arch_spec in "amd64:" "s390x:GPU=0" "ppc64le:GPU=0"; do \
+		arch=$${arch_spec%%:*}; \
+		gpu_arg=$${arch_spec#*:}; \
+		echo "Building $$arch..."; \
+		docker buildx build --platform "linux/$$arch" \
+			--file "Dockerfile.$(DIST_OS)" \
+			$(BUILD_ARGS) \
+			$${gpu_arg:+--build-arg $$gpu_arg} \
+			--tag "$(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-$$arch" \
+			--push \
+			.; \
+	done
 	@echo "Creating multi-arch manifest..."
-	docker buildx imagetools create -t $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG) \
-		$(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-amd64 \
-		$(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-s390x \
-		$(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-ppc64le
+	docker buildx imagetools create -t "$(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)" \
+		"$(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-amd64" \
+		"$(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-s390x" \
+		"$(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-ppc64le"

--- a/Makefile
+++ b/Makefile
@@ -698,3 +698,52 @@ endif
 
 run_lib_files_test:
 	docker run --entrypoint bash -v $(realpath tests/file_lists):/test $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)$(IMAGE_TAG_SUFFIX) ./test/test_release_files.sh ${BAZEL_DEBUG_FLAGS} > file_test.log 2>&1 ; exit_status=$$? ; tail -200 file_test.log ; exit $$exit_status
+
+# Multi-arch build targets
+.PHONY: docker_build_multiarch
+docker_build_multiarch:
+	@echo "Building multi-arch OVMS images for linux/amd64,linux/s390x,linux/ppc64le..."
+	docker buildx build \
+		--platform linux/amd64,linux/s390x,linux/ppc64le \
+		--file Dockerfile.$(DIST_OS) \
+		$(BUILD_ARGS) \
+		--build-arg GPU=0 \
+		--tag $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG) \
+		--push \
+		.
+
+.PHONY: docker_build_per_arch
+docker_build_per_arch:
+	@echo "Building per-arch OVMS images..."
+	# Build amd64
+	docker buildx build --platform linux/amd64 \
+		--file Dockerfile.$(DIST_OS) \
+		$(BUILD_ARGS) \
+		--tag $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-amd64 \
+		--push \
+		.
+
+	# Build s390x
+	docker buildx build --platform linux/s390x \
+		--file Dockerfile.$(DIST_OS) \
+		$(BUILD_ARGS) \
+		--build-arg GPU=0 \
+		--tag $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-s390x \
+		--push \
+		.
+
+	# Build ppc64le
+	docker buildx build --platform linux/ppc64le \
+		--file Dockerfile.$(DIST_OS) \
+		$(BUILD_ARGS) \
+		--build-arg GPU=0 \
+		--tag $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-ppc64le \
+		--push \
+		.
+
+	# Create manifest list
+	@echo "Creating multi-arch manifest..."
+	docker buildx imagetools create -t $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG) \
+		$(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-amd64 \
+		$(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-s390x \
+		$(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-ppc64le


### PR DESCRIPTION
- Modify Dockerfile.redhat with TARGETARCH conditionals
- Add architecture-specific build flags for OpenVINO
  * s390x: march=z14, LTO off, Intel features disabled
  * ppc64le: mcpu=power9, LTO off, Intel features disabled
- Replace hardcoded x86_64 paths with conditional logic
- Add multi-arch aware Bazel installer selection
- Reduce JOBS to 8 for s390x/ppc64le to prevent timeout
- Disable GPU support on non-x86 architectures
- Add Makefile targets for multi-arch builds
  * docker_build_multiarch: Build all archs in one command
  * docker_build_per_arch: Build separately then create manifest
- Add GitHub Actions workflow for multi-arch CI
  * QEMU setup for cross-platform builds
  * Multi-arch manifest verification
  * Per-arch pull tests

This enables building OVMS images that support amd64, s390x, and ppc64le architectures from a single manifest, allowing automatic architecture selection when pulling images.

### 🛠 Summary

JIRA/Issue if applicable.
Describe the changes.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI workflow to build and publish multi-architecture container images for `linux/amd64`, `linux/s390x`, and `linux/ppc64le`.
  * Introduced new build targets to publish either a single multi-arch image or per-architecture images under a shared release tag.
* **Bug Fixes**
  * Improved non-x86 build behavior by selecting the correct architecture-specific components and build steps.
  * Added post-publish verification to confirm expected platforms are present in the published manifest.
* **Documentation**
  * Added a comprehensive build guide covering multi-architecture options, troubleshooting, and validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->