### PR TITLE
testing upstream konflux build fix by removing midstream patch

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -339,32 +339,14 @@ ARG CAPI_FLAGS="--strip=always  --config=mp_off_py_off --//:distro=redhat"
 ARG JOBS=40
 ARG LTO_ENABLE=OFF
 WORKDIR /ovms
-# Konflux has a hard time locating the built binaries. Need to put it
-# in a known location.
-RUN mkdir -p /tmp/bazel-output && \
-    bazel --output_base=/tmp/bazel-output \
-        build --jobs=$JOBS ${CAPI_FLAGS} //src:ovms_shared && \
-    find /tmp/bazel-output -name libovms_shared.so && \
-    LIB_PATH=$(find /tmp/bazel-output -name libovms_shared.so | head -n1) && \
-    echo "Found built file: $LIB_PATH" && \
-    mkdir -p /ovms_release/lib && \
-    cp -v "$LIB_PATH" /ovms_release/lib/
+RUN bazel build --jobs $JOBS ${CAPI_FLAGS} //src:ovms_shared
 
 # C api app with bazel
 # hadolint ignore=DL3059
 RUN bazel build --jobs $JOBS ${CAPI_FLAGS} //src:capi_cpp_example
 
 # C-API benchmark app
-# Konflux has a hard time locating the built binaries. Need to put it
-# in a known location.
-RUN mkdir -p /tmp/bazel-output && \
-    bazel --output_base=/tmp/bazel-output \
-        build --jobs=$JOBS ${CAPI_FLAGS} //src:capi_benchmark && \
-    CAPI_BIN=$(find /tmp/bazel-output -type f -name capi_benchmark | head -n1) && \
-    echo "Found built capi_benchmark: $CAPI_BIN" && \
-    chmod +x "$CAPI_BIN" && \
-    "$CAPI_BIN" --niter 2 --nstreams 1 --servable_name "dummy"
-
+RUN bazel build --jobs=$JOBS ${CAPI_FLAGS} //src:capi_benchmark && ./bazel-bin/src/capi_benchmark --niter 2 --nstreams 1 --servable_name "dummy"
 # C-api C/C++ app with gcc
 COPY MakefileCapi /ovms/
 RUN make -f MakefileCapi cpp CAPI_FLAGS="${CAPI_FLAGS}" && \

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -339,32 +339,14 @@ ARG CAPI_FLAGS="--strip=always  --config=mp_off_py_off --//:distro=redhat"
 ARG JOBS=40
 ARG LTO_ENABLE=OFF
 WORKDIR /ovms
-# Konflux has a hard time locating the built binaries. Need to put it
-# in a known location.
-RUN mkdir -p /tmp/bazel-output && \
-    bazel --output_base=/tmp/bazel-output \
-        build --jobs=$JOBS ${CAPI_FLAGS} //src:ovms_shared && \
-    find /tmp/bazel-output -name libovms_shared.so && \
-    LIB_PATH=$(find /tmp/bazel-output -name libovms_shared.so | head -n1) && \
-    echo "Found built file: $LIB_PATH" && \
-    mkdir -p /ovms_release/lib && \
-    cp -v "$LIB_PATH" /ovms_release/lib/
+RUN bazel build --jobs $JOBS ${CAPI_FLAGS} //src:ovms_shared
 
 # C api app with bazel
 # hadolint ignore=DL3059
 RUN bazel build --jobs $JOBS ${CAPI_FLAGS} //src:capi_cpp_example
 
 # C-API benchmark app
-# Konflux has a hard time locating the built binaries. Need to put it
-# in a known location.
-RUN mkdir -p /tmp/bazel-output && \
-    bazel --output_base=/tmp/bazel-output \
-        build --jobs=$JOBS ${CAPI_FLAGS} //src:capi_benchmark && \
-    CAPI_BIN=$(find /tmp/bazel-output -type f -name capi_benchmark | head -n1) && \
-    echo "Found built capi_benchmark: $CAPI_BIN" && \
-    chmod +x "$CAPI_BIN" && \
-    "$CAPI_BIN" --niter 2 --nstreams 1 --servable_name "dummy"
-
+RUN bazel build --jobs=$JOBS ${CAPI_FLAGS} //src:capi_benchmark && ./bazel-bin/src/capi_benchmark --niter 2 --nstreams 1 --servable_name "dummy"
 # C-api C/C++ app with gcc
 COPY MakefileCapi /ovms/
 RUN make -f MakefileCapi cpp CAPI_FLAGS="${CAPI_FLAGS}" && \


### PR DESCRIPTION
### 🛠 Summary
[RHOAIENG-63342](https://redhat.atlassian.net/browse/RHOAIENG-63342)

**DO NOT MERGE**

Testing Konflux build fix merged in  https://github.com/openvinotoolkit/model_server/pull/4159

Midstream konflux build patch is reversed for the test.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``



[RHOAIENG-63342]: https://redhat.atlassian.net/browse/RHOAIENG-63342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ